### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+aseqjoy (0.0.2-3) UNRELEASED; urgency=medium
+
+  * Update watch file format version to 4.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sun, 27 Nov 2022 08:11:29 -0000
+
 aseqjoy (0.0.2-2) unstable; urgency=medium
 
   * Trim trailing whitespace.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 aseqjoy (0.0.2-3) UNRELEASED; urgency=medium
 
   * Update watch file format version to 4.
+  * Bump debhelper from old 12 to 13.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sun, 27 Nov 2022 08:11:29 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: aseqjoy
 Section: sound
 Priority: optional
 Maintainer: Fernando Toledo <ragnarok@docksud.com.ar>
-Build-Depends: debhelper-compat (= 12), libasound2-dev
+Build-Depends: debhelper-compat (= 13), libasound2-dev
 Standards-Version: 3.9.8
 Homepage: https://terminatorx.org/addons
 Vcs-Git: https://github.com/ftoledo/pkg-aseqjoy.git

--- a/debian/watch
+++ b/debian/watch
@@ -1,2 +1,2 @@
-version=3
+version=4
 https://terminatorx.org/files/ .*/aseqjoy-(\d+.\d+.\d+)\.tar\.gz


### PR DESCRIPTION
Fix some issues reported by lintian

* Update watch file format version to 4. ([older-debian-watch-file-standard](https://lintian.debian.org/tags/older-debian-watch-file-standard))
* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))


This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/aseqjoy/80577dc5-b0fd-4932-b259-cca20f446e5b.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/80577dc5-b0fd-4932-b259-cca20f446e5b/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/80577dc5-b0fd-4932-b259-cca20f446e5b/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/80577dc5-b0fd-4932-b259-cca20f446e5b/diffoscope)).
